### PR TITLE
remove license in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,3 @@ EMBEDDING-PROJECTION/
 │
 └── plots/
 ```
-
-## ⚖️ License
-embedding-projection is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
It is already present as a file and in the GitHub overview to the right